### PR TITLE
Add basic (and quite incomplete) pygments lexer

### DIFF
--- a/pygments/README.md
+++ b/pygments/README.md
@@ -1,0 +1,12 @@
+# I ❤️LA + Pygments
+
+This implements a lexer for I❤LA for pygments.
+
+Usage:
+Install pygments via pip or homebrew (`pip3 install pygments` or `brew install pygments`).
+
+Basic usage:
+`pygmentize -l ./iheartla_lexer.py -x -o <output_file.html> -O style=pastie -O full -O linenos <input file>`
+
+The options `full` and `linenos` enable generating a full HTML file and line numbers, respectively.
+To see possible styles, run `pygmentize -L styles`.

--- a/pygments/iheartla_lexer.py
+++ b/pygments/iheartla_lexer.py
@@ -1,0 +1,89 @@
+# Plugin-able lexer for pygments
+# See README for usage
+
+from pygments.lexer import ExtendedRegexLexer, bygroups, words, include
+from pygments.token import *
+
+import regex
+
+class CustomLexer(ExtendedRegexLexer):
+    name = "A Lexer for IHeartLA"
+    functions = [
+        'trace',
+        'vec',
+        'diag',
+        'eig',
+        'conj',
+        'Re',
+        'Im',
+        'inv',
+        'det',
+        'svd',
+        'rank',
+        'null',
+        'orth',
+        'qr',
+        'sum',
+        '∑',
+        'min',
+        'max',
+        'argmin',
+        'argmax',
+        'sin',
+        'asin',
+        'arcsin',
+        'cos',
+        'acos',
+        'arccos',
+        'tanh',
+        'cot',
+        'sec',
+        'csc',
+        'atan2',
+        'exp',
+        'log',
+        'ln',
+        'sqrt'
+    ]
+    word_operators = [
+        'for',
+        'if',
+        'else'
+    ]
+
+    def ident_callback(lexer, match, ctx):
+        m = regex.match(r'[A-Za-z\p{Ll}\p{Lu}\p{Lo}]\p{M}*', ctx.text[ctx.pos:ctx.end])
+        if m:
+            yield ctx.pos+m.start(), Name.Variable, m[0]
+            ctx.pos += m.end()
+            return
+        else:
+            print("Unable to treat %s as identifier\n" % m)
+            return
+
+
+    tokens = {
+        'root': [
+            (r'where', Keyword.Namespace),
+            (r'\s=\s', Keyword.Declaration), # a bit of a stretch, but it should be colored differently
+            (r'->|[\+\-±⋅×/÷\^_><]', Operator), # non-word operators
+            (words(word_operators), Operator.Word),
+            (r':', Keyword, 'where_rhs'),
+            (words(functions), Name.Function),
+            (r'[()\[\],]', Punctuation),
+            (r'ℝ', Name.Builtin),
+            (r'(`)(.*?)(`)', bygroups(Comment, Name.Variable, Comment)), # make backticks separate color
+            (r'[\u2070\u00B9\u00B2\u00B3\u2074-\u2079]|[\u2080-\u2089]|\d+', Literal.Number),
+            (r'\w', ident_callback),
+            (r'\s+?', Text),
+            (r'.*\n', Text)
+        ],
+        'where_rhs': [
+            (r'\s*:', Keyword, 'comment'),
+            (r'$', Generic, '#pop'),
+            include('root')
+        ],
+        'comment': [
+            (r'.*$', Comment, '#pop:2')
+        ]
+    }


### PR DESCRIPTION
Initial lexer for syntax highlighting via pygments.  We can keep extending this to support more of the language by inspecting the output on our examples and case studies.