### PR TITLE
Simplify CLI error messages

### DIFF
--- a/iheartla/la_parser/type_walker.py
+++ b/iheartla/la_parser/type_walker.py
@@ -10,7 +10,8 @@ from ..la_tools.la_helper import *
 ## Make the visualizer
 try: from la_tools.la_visualizer import LaVisualizer
 except ImportError:
-    print( "Skipping visualizer." )
+    if DEBUG_MODE:
+        print( "Skipping visualizer." )
     class LaVisualizer(object):
         def visualize(self, node): pass
 

--- a/iheartla/la_tools/la_msg.py
+++ b/iheartla/la_tools/la_msg.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from tatsu.util import re
 
 
 class LaMsgTypeEnum(Enum):
@@ -125,13 +126,16 @@ class LaMsg(object):
         return ''.join([' '] * column) + '^\n'
 
     def get_parse_error(self, err):
-        line_info = err.buf.line_info(err.pos)
-        converted_name = None
-        for rule in reversed(err.stack):
-            if rule in self.rule_convention_dict:
-                converted_name = self.rule_convention_dict[rule]
-                break
-        content = "{}. Failed to parse {}: {}\n".format(self.get_line_desc(line_info), converted_name, err.message)
-        content += line_info.text
-        content += self.get_pos_marker(line_info.col)
+        # from TatSu/tatsu/exceptions.py 
+        info = err.tokenizer.line_info(err.pos)
+        template = "{}({}:{}) {} :\n{}\n{}^"
+        text = info.text.rstrip()
+        leading = re.sub(r'[^\t]', ' ', text)[:info.col]
+        text = text.expandtabs()
+        leading = leading.expandtabs()
+        content = template.format(info.filename,
+                               info.line + 1, info.col + 1,
+                               err.message.rstrip(),
+                               text,
+                               leading)
         return content


### PR DESCRIPTION
suppress debug message and change get_parse_error to give error message. Fixes 
#32 

I am not able to run the GUI locally so I don't know if this messes that up. 