### PR TITLE
unncessary default packages/SetMainFont command -> usepackage{libertine}

### DIFF
--- a/iheartla/la_parser/codegen_latex.py
+++ b/iheartla/la_parser/codegen_latex.py
@@ -21,8 +21,7 @@ class CodeGenLatex(CodeGen):
 \usepackage{amssymb}
 '''[1:]
         self.pre_str += r'''
-\usepackage{ctex}
-\setmainfont{Linux Libertine O}
+\usepackage{libertine}
 '''[1:]
         self.pre_str += r'''
 \DeclareMathOperator*{\argmax}{arg\,max}


### PR DESCRIPTION
ctex seems unnecessary to include by default (maybe we should include it if we detect Chinese characters?). My pdflatex complained about something to do with it.

Similarly, `\setmainfont{Linux Libertine O}` was giving complaints. Is `\usepackage{libertine}` sufficient? That worked for me immediately. 
