### PR TITLE
fix kerning in pmp_42 gallery

### DIFF
--- a/iheartla/la_parser/codegen_latex.py
+++ b/iheartla/la_parser/codegen_latex.py
@@ -27,6 +27,10 @@ class CodeGenLatex(CodeGen):
 \DeclareMathOperator*{\argmax}{arg\,max}
 \DeclareMathOperator*{\argmin}{arg\,min}
 \usepackage[paperheight=8in,paperwidth=4in,margin=.3in,heightrounded]{geometry}
+\let\originalleft\left
+\let\originalright\right
+\renewcommand{\left}{\mathopen{}\mathclose\bgroup\originalleft}
+\renewcommand{\right}{\aftergroup\egroup\originalright}
 \begin{document}
 
 \begin{center}


### PR DESCRIPTION
![image_2021_05_15T20_21_31_966Z](https://user-images.githubusercontent.com/2241689/118377557-f894ed00-b59b-11eb-82f4-640974d94a8c.png)
becomes
![image_2021_05_15T20_25_52_792Z](https://user-images.githubusercontent.com/2241689/118377561-fc287400-b59b-11eb-895c-7603823b7ad3.png)
at the cost of having more junk in the preamble.