### PR TITLE
fix left right bar heights

### DIFF
--- a/iheartla/la_parser/codegen_latex.py
+++ b/iheartla/la_parser/codegen_latex.py
@@ -507,13 +507,13 @@ class CodeGenLatex(CodeGen):
 
     def visit_norm(self, node, **kwargs):
         if node.value.la_type.is_scalar():
-            content = "|{}|".format(self.visit(node.value, **kwargs))
+            content = "\\left|{}\\right|".format(self.visit(node.value, **kwargs))
         else:
             value_content = self.visit(node.value, **kwargs)
-            content = "\\|{}\\|".format(value_content)
+            content = "\\left\\|{}\\right\\|".format(value_content)
             if node.value.la_type.is_vector():
                 if node.norm_type == NormType.NormDet:
-                    content = "|{}|".format(value_content)
+                    content = "\\left|{}\\right|".format(value_content)
                 elif node.norm_type == NormType.NormInteger:
                     content += "_{}".format(node.sub)
                 elif node.norm_type == NormType.NormMax:
@@ -523,7 +523,7 @@ class CodeGenLatex(CodeGen):
                     content += "_{{{}}}".format(sub_info)
             elif node.value.la_type.is_matrix():
                 if node.norm_type == NormType.NormDet:
-                    content = "|{}|".format(value_content)
+                    content = "\\left|{}\\right|".format(value_content)
                 elif node.norm_type == NormType.NormFrobenius:
                     content += "_F"
                 elif node.norm_type == NormType.NormNuclear:


### PR DESCRIPTION
bars (e.g., `|` and `‖`) should act like other brackets/parenthesis (e.g., `(`) in the LaTex output and use the `\left` and `\right` modifiers to ensure that they grow to the height of their contents.