### PR TITLE
don't protect norms in latex

### DIFF
--- a/iheartla/la_parser/codegen_latex.py
+++ b/iheartla/la_parser/codegen_latex.py
@@ -496,9 +496,12 @@ class CodeGenLatex(CodeGen):
         else:
             if node.power.node_type == IRNodeType.Factor and node.power.sub:  # sub expression
                 power_info = self.visit(node.power.sub.value, **kwargs)
-                base_info = "{{{}}}^{{{}}}".format(base_info, power_info)
             else:
                 power_info = self.visit(node.power, **kwargs)
+            if node.base.node_type == IRNodeType.Norm:
+                # don't enclose norms in {} this causes ugly space.
+                base_info = "{}^{{{}}}".format(base_info, power_info)
+            else:
                 base_info = "{{{}}}^{{{}}}".format(base_info, power_info)
         return base_info
 


### PR DESCRIPTION
```
‖x‖^2

where
x∈ℝ³
```
used to produce this (ugly space to left of ^2):

<img width="429" alt="Screen Shot 2021-05-16 at 5 40 14 PM" src="https://user-images.githubusercontent.com/2241689/118413707-b25c8e00-b66e-11eb-9d7e-3a22bfc7df78.png">

after this change, norm nodes under powers are detected and not protected with extra {} in the latex output (I claim this is safe). The spacing is fixed:

<img width="411" alt="Screen Shot 2021-05-16 at 5 43 44 PM" src="https://user-images.githubusercontent.com/2241689/118413756-e46df000-b66e-11eb-90dd-24d9d17e60d4.png">
